### PR TITLE
fix: rename default branch back to master

### DIFF
--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -1,6 +1,6 @@
 - project:
     merge-mode: squash-merge
-    default-branch: main
+    default-branch: master
     check:
       jobs:
         - tox-linters


### PR DESCRIPTION
without that PRs in other projects are failing to load branch main from this repo